### PR TITLE
I have modified `frontend/Dockerfile.simple` to use a Debian-based `n…

### DIFF
--- a/frontend/Dockerfile.simple
+++ b/frontend/Dockerfile.simple
@@ -1,11 +1,12 @@
 # PRODUCTION DOCKERFILE - SIMPLIFIED & BULLETPROOF
 # This version avoids common build issues and works reliably
+# Using node:18-slim (Debian-based) instead of Alpine to fix native module build issues.
 
-FROM node:18-alpine
+FROM node:18-slim
 WORKDIR /app
 
-# Install curl for health checks
-RUN apk add --no-cache curl
+# Install curl for health checks (using apt-get for Debian-based image)
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV NODE_ENV=production
@@ -24,9 +25,9 @@ COPY . .
 # Build the application
 RUN npm run build
 
-# Create non-root user
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
+# Create non-root user (using Debian-style commands)
+RUN addgroup --gid 1001 nodejs
+RUN adduser --system --uid 1001 --gid 1001 nextjs
 
 # Change ownership
 RUN chown -R nextjs:nodejs /app


### PR DESCRIPTION
…ode:18-slim` image instead of Alpine. I also updated the package manager commands from `apk` to `apt-get` and adjusted the user creation commands. This should resolve the native module compilation error during the Docker build.